### PR TITLE
DTSPO-6488 - Update post-install script

### DIFF
--- a/neuvector-azure-keyvault/Chart.yaml
+++ b/neuvector-azure-keyvault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for NeuVector
 name: neuvector-azure-keyvault
-version: 1.1.3
+version: 1.1.4
 dependencies:
   - name: library
     version: 0.5.7

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -100,11 +100,6 @@ data:
       {{- end }}
     fi
 
-    echo "Updating state for admission rules..."
-    $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -X PATCH \
-      -d '{"state":{"enable":{{ .Values.rules.admission.enable }},"mode":"{{ .Values.rules.admission.mode }}","default_action":"{{ .Values.rules.admission.defaultAction }}","adm_client_mode":"{{ .Values.rules.admission.admClientMode }}","adm_client_mode_options":{"service":"{{ .Values.rules.admission.service }}-svc-admission-webhook.{{ .Values.rules.admission.service }}.svc","url":"https://{{ .Values.rules.admission.service }}-svc-admission-webhook.{{ .Values.rules.admission.service }}.svc:443"}}}' \
-      $API_URL/admission/state
-
     # Set response rules
     if [[ {{ len .Values.rules.response.policies }} -gt 0 ]]
     then


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-6488

Change description
Post install script fails at updating admission rules state with ```500 internal server error```
On investigation, this does not seem to be a necessary step as the state was already set to ```protect``` when I tested 
applying the resources manually

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No
