### PR TITLE
Switch dependency charts to public upstream

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       chartNamespace: neuvector
       helmDeleteWait: "300"
       helmInstallWait: "300"
-      helmInstallTimeout: "500"
+      helmInstallTimeout: "1500"
       serviceConnection: "DCD-CFTAPPS-SBOX"
       aksResourceGroup: "cft-sbox-00-rg"
       aksCluster: "cft-sbox-00-aks"

--- a/neuvector-azure-keyvault/Chart.yaml
+++ b/neuvector-azure-keyvault/Chart.yaml
@@ -8,9 +8,8 @@ dependencies:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: core
     alias: neuvector
-    version: 2.0.0
-    # TODO switch back to upstream after https://github.com/neuvector/neuvector-helm/pull/115 is merged
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    version: 2.2.4
+    repository: https://neuvector.github.io/neuvector-helm/
   - name: crd
-    version: 2.0.0
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    version: 2.2.4
+    repository: https://neuvector.github.io/neuvector-helm/

--- a/neuvector-azure-keyvault/values.yaml
+++ b/neuvector-azure-keyvault/values.yaml
@@ -24,7 +24,6 @@ config:
 
 neuvector:
   registry: hmctsprivate.azurecr.io
-  tag: 4.3.2
   crdwebhook:
     enabled: false
 

--- a/neuvector-azure-keyvault/values.yaml
+++ b/neuvector-azure-keyvault/values.yaml
@@ -23,7 +23,6 @@ config:
   forceLicenseUpdate: false
 
 neuvector:
-  registry: hmctsprivate.azurecr.io
   crdwebhook:
     enabled: false
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-10284


### Change description ###

Switch neuvector charts to upstream, keep version 1 release below latest to test renovate is working


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
