### PR TITLE
Updating chart library to V2.2.2 and OCI endpoint

### DIFF
--- a/neuvector-azure-keyvault/Chart.yaml
+++ b/neuvector-azure-keyvault/Chart.yaml
@@ -4,8 +4,8 @@ name: neuvector-azure-keyvault
 version: 1.5.17
 dependencies:
   - name: library
-    version: 2.1.0
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    version: 2.2.2
+    repository: oci://hmctspublic.azurecr.io/helm
   - name: core
     alias: neuvector
     version: 2.8.3

--- a/neuvector-azure-keyvault/templates/post-install-job.yaml
+++ b/neuvector-azure-keyvault/templates/post-install-job.yaml
@@ -28,11 +28,11 @@ spec:
           image: hmctspublic.azurecr.io/docker-curl
           command: ["/bin/sh", "-c", "/etc/config/config.sh"]
           volumeMounts:
-          {{- ( include "hmcts.secretMounts.v2" . ) | indent 10   }}
+          {{- ( include "hmcts.secretMounts.v3" . ) | indent 10   }}
             - name: config-volume
               mountPath: /etc/config
       volumes:
-      {{- ( include "hmcts.secretCSIVolumes.v2" . ) | indent 6 }}
+      {{- ( include "hmcts.secretCSIVolumes.v3" . ) | indent 6 }}
         - name: config-volume
           configMap:
             name: neuvector-restapi-config

--- a/neuvector-azure-keyvault/templates/tests/test-service.yaml
+++ b/neuvector-azure-keyvault/templates/tests/test-service.yaml
@@ -17,7 +17,7 @@ spec:
       image: hmctspublic.azurecr.io/docker-curl
       command: ["/bin/sh", "-c", "/etc/config/config.sh"]
       volumeMounts:
-      {{- ( include "hmcts.secretMounts.v2" . ) | indent 6   }}
+      {{- ( include "hmcts.secretMounts.v3" . ) | indent 6   }}
         - name: config-volume
           mountPath: /entrypoint
       env:
@@ -26,7 +26,7 @@ spec:
       command: ["sh", "-c", "/entrypoint/entrypoint.sh"]
   restartPolicy: Never
   volumes:
-  {{- ( include "hmcts.secretCSIVolumes.v2" . ) | indent 2 }}
+  {{- ( include "hmcts.secretCSIVolumes.v3" . ) | indent 2 }}
     - name: config-volume
       configMap:
         name: {{ .Release.Name }}-test-configmap


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description
Updating Chart library reference to point at the new OCI endpoint this also required bumping from v2.1.0 to v2.2.2 as part of the upgrade work for DTSPO-23130.
All base charts will need an update as part of this work.

The new release off the back of this PR will also move chart-neuvector to the OCI endpoint.

### Testing done

Tested using this [PR](https://github.com/hmcts/cnp-plum-recipes-service/pull/1118) on the cnp-plum-recipe-service repo and pipeline.
Build successfully went green with the changes in this PR using the [pre-release](https://github.com/hmcts/chart-java/releases/tag/v5.3.0-beta) for chart java V5

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
