### PR TITLE
Updating configmap to remove response rules, response rules are now CRD level resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ The hook is intentionally limited to runtime settings that the upstream chart do
 
 You can set `config.forceLicenseUpdate` to `true` to force the license reconciliation step even when the imported config already contains the same license key.
 
+## Troubleshooting / Debug Mode
+
+By default the hook script suppresses verbose curl output and response bodies to avoid leaking authentication tokens and JWTs into pod logs. When troubleshooting a failed hook run you can re-enable that output without changing the chart code by setting `config.debug` to `true` via a Flux values patch:
+
+```yaml
+spec:
+  values:
+    config:
+      debug: true
+```
+
+With debug enabled the hook will:
+
+- Pass the `-v` flag to every `curl` call, printing request and response headers (including `X-Auth-Token`).
+- Print the full response body after each JSON API call and file upload.
+
+**Remove the patch and trigger a re-reconcile once troubleshooting is complete.** Leaving debug enabled on a long-running cluster means authentication tokens will appear in the hook job logs, which are accessible to anyone with `kubectl logs` access to the `neuvector` namespace.
+
 For the secrets (for example admin password and license key) to be read from Azure Key Vault, an Azure managed identity needs to be available.
 For more information refer to the documentation related to Pod Identity and Azure provider for CSI driver:
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,48 @@
 # chart-neuvector
+
 Helm Chart for NeuVector
 
-This chart builds upon the official Neuvector Helm chart adding a job that automates post-install and post-upgrade configuration.
-As the chart pulls secrets from Azure keyvault using a secret volume, the changes are not generic enough to be merged to upstream and that is the reason for creating this derived chart.
+This chart wraps the upstream NeuVector `core` chart and adds HMCTS-specific resources around it.
+The upstream dependency is included as the aliased subchart `neuvector`, while this repository adds the Azure Key Vault integration, Helm hook automation, and local policy resources that are not maintained upstream.
 
-## Functionalities
-After installing Neuvector using the official Neuvector chart, this chart does the following:
+As the chart pulls secrets from Azure Key Vault using a secret volume, the changes are not generic enough to be merged upstream and that is the reason for creating this derived chart.
 
-1. Accepts the EULA if not accepted already (i.e. because this is an upgrade)
-2. Sets the license key if not set already. You can set `config.forceLicenseUpdate` to `true` for force updating license
-3. Changes the default admin password if it has not been changed already
-4. Sets the Slack webhook URL
-5. Sets the admission rules
-6. Sets the response rules
+## How This Chart Customizes Upstream
 
-For the secrets (e.g. admin password, license key) to be read from Azure keyvault, an Azure managed identity needs to be available.
+On top of the upstream NeuVector release, this wrapper adds the following resources and behavior:
+
+1. A post-install/post-upgrade Job runs `templates/configmap.yaml` via `templates/post-install-job.yaml`.
+2. Azure Key Vault secrets are mounted into that Job so the hook can read the admin password, replacement admin password, enterprise license, and Slack webhook.
+3. Admission control defaults are rendered as a `NvAdmissionControlSecurityRule` custom resource in `templates/admission-control.yaml`.
+4. Response rules are rendered as `NvResponseRuleSecurityRule` custom resources in `templates/response-rules.yaml`.
+
+## Post-Install Hook Responsibilities
+
+The hook script customizes the running NeuVector deployment after the upstream chart has created the core controllers and services. Its responsibilities are:
+
+1. Wait for NeuVector to finish restoring persisted state before applying API changes.
+2. Authenticate using the bootstrap secret on first install, or the Azure Key Vault admin credentials on later runs.
+3. Handle NeuVector's forced first-login password reset flow automatically when a token cannot yet be issued.
+4. Accept the EULA if it has not already been accepted.
+5. Reconcile the enterprise license from Key Vault by exporting the current NeuVector config, replacing the `object/config/license` entry, and re-importing it.
+6. Rotate the admin password to the desired Key Vault value if the cluster is still using the bootstrap or previous password.
+7. Configure the Slack webhook URL through the NeuVector system config API.
+
+The hook is intentionally limited to runtime settings that the upstream chart does not manage declaratively. Admission control and response rules are no longer created by REST calls from the hook; they are rendered by Helm as CRDs instead.
+
+You can set `config.forceLicenseUpdate` to `true` to force the license reconciliation step even when the imported config already contains the same license key.
+
+For the secrets (for example admin password and license key) to be read from Azure Key Vault, an Azure managed identity needs to be available.
 For more information refer to the documentation related to Pod Identity and Azure provider for CSI driver:
+
 - [Azure Key Vault Provider for Secrets Store CSI Driver](https://github.com/Azure/secrets-store-csi-driver-provider-azure)
 - [AAD Pod Identity](https://github.com/Azure/aad-pod-identity)
 
-The automated configuration script uses the Neuvector REST API therefore the controller service should be exposed at least internally 
+The automated configuration script uses the NeuVector REST API therefore the controller service should be exposed at least internally
 (i.e. without ingress).
 
 ## Optional http->https redirect
+
 An optional http->https redirect can be enabled on the manager ingress by setting the following boolean parameter:
 
 ```yaml
@@ -34,7 +54,7 @@ spec:
           httpredirect: true
 ```
 
-
 ## Releases
+
 We use semantic versioning via GitHub releases to handle new releases of this application chart, this is done via automation called Release Drafter. When you merge a PR to master, a new draft release will be created.
 More information is available about the [release process and how to create draft releases for testing purposes in more depth](https://hmcts.github.io/ops-runbooks/Testing-Changes/drafting-a-release.html)

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -8,13 +8,60 @@ rules:
     mode: "monitor" # one of: monitor, protect
   response:
     policies:
-      - '{"insert":{"after":0,"rules":[{"group":null,"conditions":[{"type":"name","value":"Admission.Control.Denied"}],"actions":["webhook"],"event":"admission-control","disable":false}]}}'
-      - '{"insert":{"after":1,"rules":[{"group":null,"conditions":[],"actions":["webhook"],"event":"security-event","disable":true}]}}'
-      - '{"insert":{"after":2,"rules":[{"group":null,"conditions":[{"type":"level","value":"Error"}],"actions":["webhook"],"event":"security-event","disable":true}]}}'
-      - '{"insert":{"after":3,"rules":[{"group":null,"conditions":[{"type":"name","value":"Container.Privilege.Escalation"}],"actions":["quarantine"],"event":"security-event","disable":true}]}}'
-      - '{"insert":{"after":4,"rules":[{"group":null,"conditions":[{"type":"cve-high","value":"10"}],"actions":["quarantine"],"event":"cve-report","disable":true}]}}'
-      - '{"insert":{"after":5,"rules":[{"group":null,"conditions":[{"type":"name","value":"Container.Quarantined"}],"actions":["webhook"],"event":"event","disable":false}]}}'
-      - '{"insert":{"after":6,"rules":[{"group":null,"conditions":[{"type":"name","value":"5.4"}],"actions":["webhook"],"event":"compliance","disable":true}]}}'
+      - name: admission-control-denied
+        event: admission-control
+        conditions:
+          - type: name
+            value: Admission.Control.Denied
+        actions:
+          - webhook
+        disable: false
+      - name: security-event-all
+        event: security-event
+        conditions: []
+        actions:
+          - webhook
+        disable: true
+      - name: security-event-error
+        event: security-event
+        conditions:
+          - type: level
+            value: Error
+        actions:
+          - webhook
+        disable: true
+      - name: security-event-privilege-escalation
+        event: security-event
+        conditions:
+          - type: name
+            value: Container.Privilege.Escalation
+        actions:
+          - quarantine
+        disable: true
+      - name: cve-report-high
+        event: cve-report
+        conditions:
+          - type: cve-high
+            value: "10"
+        actions:
+          - quarantine
+        disable: true
+      - name: event-container-quarantined
+        event: event
+        conditions:
+          - type: name
+            value: Container.Quarantined
+        actions:
+          - webhook
+        disable: false
+      - name: compliance-5-4
+        event: compliance
+        conditions:
+          - type: name
+            value: "5.4"
+        actions:
+          - webhook
+        disable: true
 config:
   sleep: 10 # we dont use backup in ci, we don't need long sleep
 

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -68,16 +68,16 @@ config:
 keyVaults:
   cftneuvector:
     secrets:
-      - neuvector-admin-password  
+      - neuvector-admin-password
       - neuvector-license-dev
       - neuvector-slack-webhook
       - neuvector-new-admin-password
 global:
-  enableKeyVaults: true 
+  enableKeyVaults: true
   tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
   environment: sbox
 
-keyvault: 
+keyvault:
   name: cftneuvector
   licensesecretname: neuvector-license-dev
 

--- a/neuvector-azure-keyvault/Chart.yaml
+++ b/neuvector-azure-keyvault/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     repository: oci://hmctsprod.azurecr.io/helm
   - name: core
     alias: neuvector
-    version: 2.8.7
+    version: 2.8.12
     repository: https://neuvector.github.io/neuvector-helm/

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -13,63 +13,425 @@ data:
 
     set -e
 
-    # NV API URL. Note just using hostname doesn't always resolve...
+    # NV API URL. The wrapper talks to the controller service from the hook job
+    # so it can finish the configuration that upstream Helm does not manage.
     API_URL="https://neuvector-svc-controller.neuvector.svc.cluster.local:10443/v1"
 
-    # Key Vault secrets
+    # Pull the desired runtime configuration from the mounted Key Vault files.
+    # These values are used to bootstrap admin access and then reconcile the
+    # cluster into the expected post-install state.
     NV_ADMIN_PASSWORD=$(cat /mnt/secrets/{{ .Values.keyvault.name }}/neuvector-admin-password)
     NV_NEW_ADMIN_PASSWORD=$(cat  /mnt/secrets/{{ .Values.keyvault.name }}/neuvector-new-admin-password)
     NV_LICENSE=$(cat /mnt/secrets/{{ .Values.keyvault.name }}/{{ .Values.keyvault.licensesecretname }})
     NV_SLACK_WEBHOOK=$(cat /mnt/secrets/{{ .Values.keyvault.name }}/neuvector-slack-webhook)
+    NV_BOOTSTRAP_PASSWORD=""
+    if [ -f /mnt/bootstrap-secret/bootstrapPassword ]
+    then
+      NV_BOOTSTRAP_PASSWORD=$(cat /mnt/bootstrap-secret/bootstrapPassword)
+    fi
 
-    # alias curl for convenience
-    _CURL="curl -sk --show-error --fail"
+    TEMP_FILES=""
 
-    # sleep as neuvector backup loads asynchronously, and has caused corrupted config
+    register_temp_file() {
+      TEMP_FILES="$TEMP_FILES $1"
+    }
+
+    cleanup_temp_files() {
+      if [ -n "$TEMP_FILES" ]
+      then
+        rm -f $TEMP_FILES
+      fi
+    }
+
+    trap cleanup_temp_files EXIT HUP INT TERM
+
+    # Execute a JSON REST call and keep both the HTTP status and body available
+    # to the caller for follow-up decisions.
+    curl_json() {
+      METHOD="$1"
+      URL="$2"
+      PAYLOAD="$3"
+      AUTH_TOKEN="$4"
+      EXTRA_HEADER="$5"
+
+      RESPONSE_FILE=$(mktemp)
+      register_temp_file "$RESPONSE_FILE"
+      set -- -skv --show-error -o "$RESPONSE_FILE" -w "%{http_code}" -X "$METHOD" -H "Content-Type: application/json"
+      if [ -n "$AUTH_TOKEN" ]
+      then
+        set -- "$@" -H "X-Auth-Token: $AUTH_TOKEN"
+      fi
+      if [ -n "$EXTRA_HEADER" ]
+      then
+        set -- "$@" -H "$EXTRA_HEADER"
+      fi
+      if [ -n "$PAYLOAD" ]
+      then
+        set -- "$@" -d "$PAYLOAD"
+      fi
+
+      set +e
+      HTTP_CODE=$(curl "$@" "$URL")
+      CURL_EXIT_CODE=$?
+      set -e
+
+      JSON_RESPONSE=$(cat "$RESPONSE_FILE")
+      rm -f "$RESPONSE_FILE"
+
+      echo "HTTP status: $HTTP_CODE"
+      echo "Response body: $JSON_RESPONSE"
+
+      JSON_STATUS="$HTTP_CODE"
+      return "$CURL_EXIT_CODE"
+    }
+
+    # Download a response body straight to disk. This is used for the gzip
+    # config export that becomes the base for license reconciliation.
+    curl_download() {
+      METHOD="$1"
+      URL="$2"
+      OUTPUT_FILE="$3"
+      AUTH_TOKEN="$4"
+      EXTRA_HEADER="$5"
+
+      set -- -skv --show-error -o "$OUTPUT_FILE" -w "%{http_code}" -X "$METHOD"
+      if [ -n "$AUTH_TOKEN" ]
+      then
+        set -- "$@" -H "X-Auth-Token: $AUTH_TOKEN"
+      fi
+      if [ -n "$EXTRA_HEADER" ]
+      then
+        set -- "$@" -H "$EXTRA_HEADER"
+      fi
+
+      set +e
+      HTTP_CODE=$(curl "$@" "$URL")
+      CURL_EXIT_CODE=$?
+      set -e
+
+      echo "HTTP status: $HTTP_CODE"
+      echo "Response body saved to: $OUTPUT_FILE"
+      echo "Response body size: $(wc -c < "$OUTPUT_FILE") bytes"
+
+      JSON_STATUS="$HTTP_CODE"
+      return "$CURL_EXIT_CODE"
+    }
+
+    # Upload a binary payload, primarily for the gzip config import endpoint.
+    curl_file() {
+      METHOD="$1"
+      URL="$2"
+      INPUT_FILE="$3"
+      CONTENT_TYPE="$4"
+      AUTH_TOKEN="$5"
+      EXTRA_HEADER="$6"
+
+      RESPONSE_FILE=$(mktemp)
+      register_temp_file "$RESPONSE_FILE"
+      set -- -skv --show-error -o "$RESPONSE_FILE" -w "%{http_code}" -X "$METHOD" -H "Content-Type: $CONTENT_TYPE" --data-binary "@$INPUT_FILE"
+      if [ -n "$AUTH_TOKEN" ]
+      then
+        set -- "$@" -H "X-Auth-Token: $AUTH_TOKEN"
+      fi
+      if [ -n "$EXTRA_HEADER" ]
+      then
+        set -- "$@" -H "$EXTRA_HEADER"
+      fi
+
+      set +e
+      HTTP_CODE=$(curl "$@" "$URL")
+      CURL_EXIT_CODE=$?
+      set -e
+
+      JSON_RESPONSE=$(cat "$RESPONSE_FILE")
+      rm -f "$RESPONSE_FILE"
+
+      echo "HTTP status: $HTTP_CODE"
+      echo "Response body: $JSON_RESPONSE"
+
+      JSON_STATUS="$HTTP_CODE"
+      return "$CURL_EXIT_CODE"
+    }
+
+    # NeuVector 2.8.12 stores the license inside the exported config set rather
+    # than exposing the legacy license update endpoints. Export the current
+    # config, replace only the license key, and re-import the result so the rest
+    # of the config section stays intact.
+    prepare_license_import() {
+      CONFIG_EXPORT_GZ=$(mktemp)
+      register_temp_file "$CONFIG_EXPORT_GZ"
+      CONFIG_EXPORT_TXT=$(mktemp)
+      register_temp_file "$CONFIG_EXPORT_TXT"
+      CONFIG_IMPORT_TXT=$(mktemp)
+      register_temp_file "$CONFIG_IMPORT_TXT"
+      CONFIG_IMPORT_GZ=$(mktemp)
+      register_temp_file "$CONFIG_IMPORT_GZ"
+
+      echo "Exporting current NeuVector configuration..."
+      curl_download GET "$API_URL/file/config?raw=true" "$CONFIG_EXPORT_GZ" "$TOKEN" ""
+      if [ "$JSON_STATUS" != "200" ]
+      then
+        echo "Failed to export current NeuVector configuration before license import."
+        return 1
+      fi
+
+      if ! gzip -dc "$CONFIG_EXPORT_GZ" > "$CONFIG_EXPORT_TXT"
+      then
+        echo "Failed to decompress the exported NeuVector configuration."
+        return 1
+      fi
+
+      CURRENT_LICENSE=$(awk 'found { print; exit } $0 == "object/config/license" { found = 1 }' "$CONFIG_EXPORT_TXT")
+      if [ -n "$CURRENT_LICENSE" ]
+      then
+        echo "Detected an existing NeuVector license in the exported configuration."
+      else
+        echo "No existing NeuVector license was found in the exported configuration."
+      fi
+
+      if [ "$CURRENT_LICENSE" = "$NV_LICENSE" ] && [ {{ .Values.config.forceLicenseUpdate }} != "true" ]
+      then
+        echo "Current NeuVector license already matches the desired license. Skipping import."
+        rm -f "$CONFIG_EXPORT_GZ" "$CONFIG_EXPORT_TXT" "$CONFIG_IMPORT_TXT" "$CONFIG_IMPORT_GZ"
+        return 2
+      fi
+
+      awk -v license="$NV_LICENSE" '
+        BEGIN {
+          license_key = "object/config/license"
+          replace_next = 0
+          replaced = 0
+        }
+        {
+          if (replace_next) {
+            print license
+            replace_next = 0
+            replaced = 1
+            next
+          }
+
+          print
+
+          if ($0 == license_key) {
+            replace_next = 1
+          }
+        }
+        END {
+          if (!replaced) {
+            print license_key
+            print license
+          }
+        }
+      ' "$CONFIG_EXPORT_TXT" > "$CONFIG_IMPORT_TXT"
+
+      if ! gzip -c "$CONFIG_IMPORT_TXT" > "$CONFIG_IMPORT_GZ"
+      then
+        echo "Failed to gzip the NeuVector configuration import payload."
+        return 1
+      fi
+
+      rm -f "$CONFIG_EXPORT_GZ" "$CONFIG_EXPORT_TXT" "$CONFIG_IMPORT_TXT"
+      LICENSE_IMPORT_FILE="$CONFIG_IMPORT_GZ"
+      return 0
+    }
+
+    # Config import is asynchronous. Poll the transaction until NeuVector marks
+    # it complete, or fail the hook so the release surfaces the problem.
+    wait_for_config_import() {
+      IMPORT_TID="$1"
+      ATTEMPT=0
+      MAX_ATTEMPTS=30
+
+      while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]
+      do
+        ATTEMPT=$((ATTEMPT + 1))
+        echo "Polling NeuVector config import status attempt $ATTEMPT/$MAX_ATTEMPTS..."
+        curl_json POST "$API_URL/file/config" "" "$TOKEN" "X-Transaction-ID: $IMPORT_TID"
+
+        IMPORT_STATUS=$(echo "$JSON_RESPONSE" | jq -r '.data.status // empty')
+        IMPORT_PERCENTAGE=$(echo "$JSON_RESPONSE" | jq -r '.data.percentage // "unknown"')
+        echo "Import status: $IMPORT_STATUS"
+        echo "Import percentage: $IMPORT_PERCENTAGE"
+
+        if [ "$JSON_STATUS" = "200" ] && [ "$IMPORT_STATUS" = "done" ]
+        then
+          return 0
+        fi
+
+        if [ "$JSON_STATUS" = "206" ] || [ "$IMPORT_STATUS" = "preparing" ] || [ "$IMPORT_STATUS" = "importing" ] || [ "$IMPORT_STATUS" = "no_response" ]
+        then
+          sleep 2
+          continue
+        fi
+
+        echo "NeuVector config import did not complete successfully."
+        return 1
+      done
+
+      echo "Timed out waiting for the NeuVector config import to complete."
+      return 1
+    }
+
+    # Build JSON payloads from stdin so passwords are not exposed in the jq
+    # command line visible via process listings.
+    auth_payload() {
+      printf '%s\n' "$1" | jq -Rn '{password:{username:"admin",password:input}}'
+    }
+
+    reset_auth_payload() {
+      printf '%s\n%s\n' "$1" "$2" | jq -Rn '(input) as $password | (input) as $new_password | {password:{username:"admin",password:$password,new_password:$new_password}}'
+    }
+
+    password_change_payload() {
+      printf '%s\n%s\n' "$1" "$2" | jq -Rn '(input) as $password | (input) as $new_password | {config:{fullname:"admin",password:$password,new_password:$new_password}}'
+    }
+
+    # Try a password source and handle first-login password reset when the
+    # controller requires it before issuing a token.
+    authenticate() {
+      PASSWORD_LABEL="$1"
+      PASSWORD_VALUE="$2"
+
+      if [ -z "$PASSWORD_VALUE" ]
+      then
+        echo "Skipping $PASSWORD_LABEL authentication because the password is empty."
+        return 1
+      fi
+
+      echo "Authenticating with $PASSWORD_LABEL password..."
+      AUTH_PAYLOAD=$(auth_payload "$PASSWORD_VALUE")
+      curl_json POST "$API_URL/auth" "$AUTH_PAYLOAD" ""
+      if [ "$JSON_STATUS" = "200" ]
+      then
+        TOKEN=$(echo "$JSON_RESPONSE" | jq -r .token.token)
+        if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]
+        then
+          CURRENT_ADMIN_PASSWORD="$PASSWORD_VALUE"
+          CURRENT_PASSWORD_SOURCE="$PASSWORD_LABEL"
+          return 0
+        fi
+
+        NEED_TO_RESET_PASSWORD=$(echo "$JSON_RESPONSE" | jq -r '.need_to_reset_password // false')
+        if [ "$NEED_TO_RESET_PASSWORD" = "true" ]
+        then
+          echo "$PASSWORD_LABEL password requires reset before a token will be issued."
+          RESET_AUTH_PAYLOAD=$(reset_auth_payload "$PASSWORD_VALUE" "$NV_NEW_ADMIN_PASSWORD")
+          curl_json POST "$API_URL/auth" "$RESET_AUTH_PAYLOAD" ""
+          if [ "$JSON_STATUS" = "200" ]
+          then
+            TOKEN=$(echo "$JSON_RESPONSE" | jq -r .token.token)
+            if [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ]
+            then
+              CURRENT_ADMIN_PASSWORD="$NV_NEW_ADMIN_PASSWORD"
+              CURRENT_PASSWORD_SOURCE="keyvault-new-admin"
+              _NEW_TOKEN="1"
+              return 0
+            fi
+          fi
+        fi
+      fi
+
+      return 1
+    }
+
+    # Upstream NeuVector can still be restoring persisted state when the hook
+    # starts. Wait before making API changes so we do not race that recovery.
     echo "Delay configuration for neuvector to load backup first..."
     sleep {{ .Values.config.sleep }}
 
-    # Authenticate and check if password has been changed
-    echo "Getting default authentication token..."
-    set +e
-    RESULT=$($_CURL  -H "Content-Type: application/json" -d '{"password": {"username": "admin", "password": "'"$NV_ADMIN_PASSWORD"'"}}' "$API_URL/auth")
-    EXIT_CODE=$?
-    set -e
-    if [ $EXIT_CODE -ne 0 ]
+    TOKEN=""
+    CURRENT_ADMIN_PASSWORD=""
+    CURRENT_PASSWORD_SOURCE=""
+    _NEW_TOKEN=""
+
+    # Prefer the bootstrap secret on fresh installs, then fall back to the Key
+    # Vault passwords for upgrades and already-initialized clusters.
+    if authenticate bootstrap "$NV_BOOTSTRAP_PASSWORD"
     then
-      echo "Getting authentication token..."
-      TOKEN=$($_CURL  -H "Content-Type: application/json" -d '{"password": {"username": "admin", "password": "'"$NV_NEW_ADMIN_PASSWORD"'"}}' "$API_URL/auth" | jq -r .token.token)
+      echo "Authenticated with bootstrap password."
+    elif authenticate keyvault-admin "$NV_ADMIN_PASSWORD"
+    then
+      echo "Authenticated with admin password from Key Vault."
+    elif authenticate keyvault-new-admin "$NV_NEW_ADMIN_PASSWORD"
+    then
+      echo "Authenticated with new admin password from Key Vault."
       _NEW_TOKEN="1"
     else
-      TOKEN=$(echo "${RESULT}" | jq -r .token.token)
+      echo "Unable to authenticate to the NeuVector API with bootstrap, admin, or new admin passwords."
+      exit 1
     fi
 
+    # The EULA must be accepted before the remaining system configuration can be
+    # applied consistently.
     echo "Accepting EULA..."
-    EULA_RESPONSE=$(curl -vk -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" $API_URL/eula)
-    echo "${EULA_RESPONSE}"
-    EULA=$(echo "${EULA_RESPONSE}" | jq -r .eula.accepted)
-    if [[ "$EULA" != "true" ]]
+    curl_json GET "$API_URL/eula" "" "$TOKEN"
+    EULA=$(echo "$JSON_RESPONSE" | jq -r .eula.accepted)
+    if [ "$EULA" != "true" ]
     then
-      $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d '{"eula":{"accepted":true}}' $API_URL/eula
+      curl_json POST "$API_URL/eula" '{"eula":{"accepted":true}}' "$TOKEN"
     fi
 
+    # Reconcile the enterprise license. The wrapper round-trips the exported
+    # config because the current upstream version manages license state as part
+    # of config import/export.
     echo "Setting license..."
-    LICENSE=$($_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" $API_URL/system/license | jq -r .license.info.email)
-    echo "Currently registered to $LICENSE"
-    if [[ "$LICENSE" == "null" || {{ .Values.config.forceLicenseUpdate }} == "true" ]]
+    if [ -z "$NV_LICENSE" ]
     then
-      $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -d '{"license_key": "'"$NV_LICENSE"'"}' $API_URL/system/license/update
+      echo "Skipping license configuration because the license value is empty."
+    else
+      if prepare_license_import
+      then
+        echo "Importing NeuVector configuration with the updated enterprise license..."
+        curl_file POST "$API_URL/file/config" "$LICENSE_IMPORT_FILE" "application/x-gzip" "$TOKEN" ""
+        if [ "$JSON_STATUS" != "206" ] && [ "$JSON_STATUS" != "200" ]
+        then
+          echo "Failed to start the NeuVector license import."
+          exit 1
+        fi
+
+        IMPORT_TID=$(echo "$JSON_RESPONSE" | jq -r '.data.tid // empty')
+        if [ -z "$IMPORT_TID" ] || [ "$IMPORT_TID" = "null" ]
+        then
+          echo "NeuVector did not return an import transaction ID for the license import."
+          exit 1
+        fi
+
+        if ! wait_for_config_import "$IMPORT_TID"
+        then
+          exit 1
+        fi
+
+        # Successful config import invalidates the current session, so obtain a
+        # fresh token before continuing with the remaining customizations.
+        echo "Re-authenticating after NeuVector config import..."
+        if ! authenticate "$CURRENT_PASSWORD_SOURCE" "$CURRENT_ADMIN_PASSWORD"
+        then
+          echo "Unable to re-authenticate after the NeuVector license import completed."
+          exit 1
+        fi
+      else
+        PREPARE_LICENSE_IMPORT_RC=$?
+        if [ "$PREPARE_LICENSE_IMPORT_RC" -ne 2 ]
+        then
+          echo "Failed to prepare the NeuVector license import payload."
+          exit 1
+        fi
+      fi
     fi
 
-    # Change admin password
-    if [ "$_NEW_TOKEN" == "" ]
+    # Once a stable token exists, rotate the admin password to the desired Key
+    # Vault value unless we already authenticated with that final password.
+    if [ "$_NEW_TOKEN" = "" ]
     then
-      echo "Changing default admin password..."
-      $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" $API_URL/user/admin -X PATCH -d '{"config":{"fullname":"admin","password":"'"$NV_ADMIN_PASSWORD"'","new_password":"'"$NV_NEW_ADMIN_PASSWORD"'"}}'
+      echo "Changing admin password from $CURRENT_PASSWORD_SOURCE to keyvault-new-admin..."
+      PASSWORD_PAYLOAD=$(password_change_payload "$CURRENT_ADMIN_PASSWORD" "$NV_NEW_ADMIN_PASSWORD")
+      curl_json PATCH "$API_URL/user/admin" "$PASSWORD_PAYLOAD" "$TOKEN"
       echo "Re-authenticating..."
-      TOKEN=$($_CURL  -H "Content-Type: application/json" -d '{"password": {"username": "admin", "password": "'"$NV_NEW_ADMIN_PASSWORD"'"}}' "$API_URL/auth" | jq -r .token.token)
+      authenticate keyvault-new-admin "$NV_NEW_ADMIN_PASSWORD"
     fi
 
-    # Set the Slack webhook URL
+    # Apply the Slack webhook after authentication and license reconciliation so
+    # alerting is aligned with the desired cluster configuration.
     echo "Setting Slack webhook URL..."
-    $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" $API_URL/system/config -X PATCH -d '{"config":{"webhook_status":true,"webhook_url":"'"$NV_SLACK_WEBHOOK"'"}}'
+    WEBHOOK_PAYLOAD=$(jq -nc --arg webhook_url "$NV_SLACK_WEBHOOK" '{config:{webhook_status:true,webhook_url:$webhook_url}}')
+    curl_json PATCH "$API_URL/system/config" "$WEBHOOK_PAYLOAD" "$TOKEN"

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -73,15 +73,3 @@ data:
     # Set the Slack webhook URL
     echo "Setting Slack webhook URL..."
     $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" $API_URL/system/config -X PATCH -d '{"config":{"webhook_status":true,"webhook_url":"'"$NV_SLACK_WEBHOOK"'"}}'
-    
-    # Set response rules
-    if [[ {{ len .Values.rules.response.policies }} -gt 0 ]]
-    then
-      echo "Deleting existing response rules..."
-      $_CURL  -H "X-Auth-Token: $TOKEN" -X DELETE "$API_URL/response/rule?scope=local"
-      echo "Setting response rules..."
-      {{- range $ar := $.Values.rules.response.policies }}
-      echo "Setting response rule: '{{ $ar | toJson }}'"
-      $_CURL  -H "Content-Type: application/json" -H "X-Auth-Token: $TOKEN" -X PATCH -d '{{ $ar }}' "$API_URL/response/rule?scope=local"
-      {{- end }}
-    fi

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -211,7 +211,7 @@ data:
         echo "No existing NeuVector license was found in the exported configuration."
       fi
 
-      if [ "$CURRENT_LICENSE" = "$NV_LICENSE" ] && [ {{ .Values.config.forceLicenseUpdate }} != "true" ]
+      if [ "$CURRENT_LICENSE" = "$NV_LICENSE" ] && [ {{ .Values.config.forceLicenseUpdate | default false | quote }} != "true" ]
       then
         echo "Current NeuVector license already matches the desired license. Skipping import."
         rm -f "$CONFIG_EXPORT_GZ" "$CONFIG_EXPORT_TXT" "$CONFIG_IMPORT_TXT" "$CONFIG_IMPORT_GZ"

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -482,3 +482,9 @@ data:
     echo "Setting Slack webhook URL..."
     WEBHOOK_PAYLOAD=$(jq -nc --arg webhook_url "$NV_SLACK_WEBHOOK" '{config:{webhook_status:true,webhook_url:$webhook_url}}')
     curl_json PATCH "$API_URL/system/config" "$WEBHOOK_PAYLOAD" "$TOKEN"
+    if [ "$JSON_STATUS" != "200" ]
+    then
+      echo "Failed to update the Slack webhook configuration. HTTP status: $JSON_STATUS"
+      echo "$JSON_RESPONSE"
+      exit 1
+    fi

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -270,6 +270,21 @@ data:
         echo "Polling NeuVector config import status attempt $ATTEMPT/$MAX_ATTEMPTS..."
         curl_json POST "$API_URL/file/config" "" "$TOKEN" "X-Transaction-ID: $IMPORT_TID"
 
+        # The NeuVector controller restarts itself after applying a config import,
+        # which invalidates the current session. Re-authenticate and keep polling
+        # rather than treating this as a terminal failure.
+        if [ "$JSON_STATUS" = "401" ]
+        then
+          echo "Session expired during import polling (controller may be restarting). Re-authenticating..."
+          if ! authenticate "$CURRENT_PASSWORD_SOURCE" "$CURRENT_ADMIN_PASSWORD"
+          then
+            echo "Unable to re-authenticate during config import polling."
+            return 1
+          fi
+          sleep 2
+          continue
+        fi
+
         IMPORT_STATUS=$(echo "$JSON_RESPONSE" | jq -r '.data.status // empty')
         IMPORT_PERCENTAGE=$(echo "$JSON_RESPONSE" | jq -r '.data.percentage // "unknown"')
         echo "Import status: $IMPORT_STATUS"

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -406,6 +406,11 @@ data:
     if [ "$EULA" != "true" ]
     then
       curl_json POST "$API_URL/eula" '{"eula":{"accepted":true}}' "$TOKEN"
+      if [ "$JSON_STATUS" != "200" ]
+      then
+        echo "Failed to accept the NeuVector EULA. Expected HTTP 200 but received $JSON_STATUS."
+        exit 1
+      fi
     fi
 
     # Reconcile the enterprise license. The wrapper round-trips the exported

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -468,6 +468,11 @@ data:
       echo "Changing admin password from $CURRENT_PASSWORD_SOURCE to keyvault-new-admin..."
       PASSWORD_PAYLOAD=$(password_change_payload "$CURRENT_ADMIN_PASSWORD" "$NV_NEW_ADMIN_PASSWORD")
       curl_json PATCH "$API_URL/user/admin" "$PASSWORD_PAYLOAD" "$TOKEN"
+      if [ "$JSON_STATUS" != "200" ]
+      then
+        echo "Failed to change the NeuVector admin password."
+        exit 1
+      fi
       echo "Re-authenticating..."
       authenticate keyvault-new-admin "$NV_NEW_ADMIN_PASSWORD"
     fi

--- a/neuvector-azure-keyvault/templates/configmap.yaml
+++ b/neuvector-azure-keyvault/templates/configmap.yaml
@@ -17,6 +17,11 @@ data:
     # so it can finish the configuration that upstream Helm does not manage.
     API_URL="https://neuvector-svc-controller.neuvector.svc.cluster.local:10443/v1"
 
+    # When debug mode is enabled via a Flux values patch, verbose curl output
+    # and response bodies are printed to assist troubleshooting without
+    # requiring a code change to the chart.
+    DEBUG="{{ .Values.config.debug | default false }}"
+
     # Pull the desired runtime configuration from the mounted Key Vault files.
     # These values are used to bootstrap admin access and then reconcile the
     # cluster into the expected post-install state.
@@ -56,7 +61,11 @@ data:
 
       RESPONSE_FILE=$(mktemp)
       register_temp_file "$RESPONSE_FILE"
-      set -- -skv --show-error -o "$RESPONSE_FILE" -w "%{http_code}" -X "$METHOD" -H "Content-Type: application/json"
+      set -- -sk --show-error -o "$RESPONSE_FILE" -w "%{http_code}" -X "$METHOD" -H "Content-Type: application/json"
+      if [ "$DEBUG" = "true" ]
+      then
+        set -- "$@" -v
+      fi
       if [ -n "$AUTH_TOKEN" ]
       then
         set -- "$@" -H "X-Auth-Token: $AUTH_TOKEN"
@@ -79,7 +88,10 @@ data:
       rm -f "$RESPONSE_FILE"
 
       echo "HTTP status: $HTTP_CODE"
-      echo "Response body: $JSON_RESPONSE"
+      if [ "$DEBUG" = "true" ]
+      then
+        echo "Response body: $JSON_RESPONSE"
+      fi
 
       JSON_STATUS="$HTTP_CODE"
       return "$CURL_EXIT_CODE"
@@ -94,7 +106,11 @@ data:
       AUTH_TOKEN="$4"
       EXTRA_HEADER="$5"
 
-      set -- -skv --show-error -o "$OUTPUT_FILE" -w "%{http_code}" -X "$METHOD"
+      set -- -sk --show-error -o "$OUTPUT_FILE" -w "%{http_code}" -X "$METHOD"
+      if [ "$DEBUG" = "true" ]
+      then
+        set -- "$@" -v
+      fi
       if [ -n "$AUTH_TOKEN" ]
       then
         set -- "$@" -H "X-Auth-Token: $AUTH_TOKEN"
@@ -110,7 +126,6 @@ data:
       set -e
 
       echo "HTTP status: $HTTP_CODE"
-      echo "Response body saved to: $OUTPUT_FILE"
       echo "Response body size: $(wc -c < "$OUTPUT_FILE") bytes"
 
       JSON_STATUS="$HTTP_CODE"
@@ -128,7 +143,11 @@ data:
 
       RESPONSE_FILE=$(mktemp)
       register_temp_file "$RESPONSE_FILE"
-      set -- -skv --show-error -o "$RESPONSE_FILE" -w "%{http_code}" -X "$METHOD" -H "Content-Type: $CONTENT_TYPE" --data-binary "@$INPUT_FILE"
+      set -- -sk --show-error -o "$RESPONSE_FILE" -w "%{http_code}" -X "$METHOD" -H "Content-Type: $CONTENT_TYPE" --data-binary "@$INPUT_FILE"
+      if [ "$DEBUG" = "true" ]
+      then
+        set -- "$@" -v
+      fi
       if [ -n "$AUTH_TOKEN" ]
       then
         set -- "$@" -H "X-Auth-Token: $AUTH_TOKEN"
@@ -147,7 +166,10 @@ data:
       rm -f "$RESPONSE_FILE"
 
       echo "HTTP status: $HTTP_CODE"
-      echo "Response body: $JSON_RESPONSE"
+      if [ "$DEBUG" = "true" ]
+      then
+        echo "Response body: $JSON_RESPONSE"
+      fi
 
       JSON_STATUS="$HTTP_CODE"
       return "$CURL_EXIT_CODE"

--- a/neuvector-azure-keyvault/templates/network.yaml
+++ b/neuvector-azure-keyvault/templates/network.yaml
@@ -4,7 +4,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: allpods
-    namespace: ""
   spec:
     dlp:
       settings: []
@@ -157,7 +156,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: applicationinsights
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -186,7 +184,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: azurepostgresql
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -206,7 +203,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: govukbankholidays
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -226,7 +222,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: govuknotify
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -246,7 +241,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: govukpay
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -266,7 +260,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: idam
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -286,7 +279,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: servicebus
-    namespace: ""
   spec:
     egress: []
     file: []
@@ -306,7 +298,6 @@ items:
   kind: NvClusterSecurityRule
   metadata:
     name: containers
-    namespace: ""
   spec:
     dlp:
       settings: []

--- a/neuvector-azure-keyvault/templates/post-install-job.yaml
+++ b/neuvector-azure-keyvault/templates/post-install-job.yaml
@@ -29,10 +29,17 @@ spec:
           command: ["/bin/sh", "-c", "/etc/config/config.sh"]
           volumeMounts:
           {{- ( include "hmcts.secretMounts.v3" . ) | indent 10   }}
+            - name: bootstrap-secret
+              mountPath: /mnt/bootstrap-secret
+              readOnly: true
             - name: config-volume
               mountPath: /etc/config
       volumes:
       {{- ( include "hmcts.secretCSIVolumes.v3" . ) | indent 6 }}
+        - name: bootstrap-secret
+          secret:
+            secretName: neuvector-bootstrap-secret
+            optional: true
         - name: config-volume
           configMap:
             name: neuvector-restapi-config

--- a/neuvector-azure-keyvault/templates/response-rules.yaml
+++ b/neuvector-azure-keyvault/templates/response-rules.yaml
@@ -1,0 +1,38 @@
+{{- range $policy := .Values.rules.response.policies }}
+---
+apiVersion: neuvector.com/v1
+kind: NvResponseRuleSecurityRule
+metadata:
+  name: {{ $policy.name }}
+  labels:
+    chart: {{ template "chart-neuvector.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+spec:
+  rule:
+    policy_name: {{ default "default" $policy.policy_name }}
+    event: {{ $policy.event }}
+    {{- if $policy.comment }}
+    comment: {{ $policy.comment | quote }}
+    {{- end }}
+    {{- if $policy.conditions }}
+    conditions:
+      {{- range $policy.conditions }}
+      - type: {{ .type }}
+        value: {{ .value | quote }}
+      {{- end }}
+    {{- else }}
+    conditions: []
+    {{- end }}
+    actions:
+      {{- range $policy.actions }}
+      - {{ . }}
+      {{- end }}
+    {{- if $policy.webhooks }}
+    webhooks:
+      {{- range $policy.webhooks }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    disable: {{ default false $policy.disable }}
+{{- end }}

--- a/neuvector-azure-keyvault/templates/response-rules.yaml
+++ b/neuvector-azure-keyvault/templates/response-rules.yaml
@@ -24,10 +24,14 @@ spec:
     {{- else }}
     conditions: []
     {{- end }}
+    {{- if $policy.actions }}
     actions:
       {{- range $policy.actions }}
       - {{ . }}
       {{- end }}
+    {{- else }}
+    actions: []
+    {{- end }}
     {{- if $policy.webhooks }}
     webhooks:
       {{- range $policy.webhooks }}

--- a/neuvector-azure-keyvault/templates/response-rules.yaml
+++ b/neuvector-azure-keyvault/templates/response-rules.yaml
@@ -3,7 +3,7 @@
 apiVersion: neuvector.com/v1
 kind: NvResponseRuleSecurityRule
 metadata:
-  name: {{ $policy.name }}
+  name: {{ required "rules.response.policies[].name is required" $policy.name | lower | replace "_" "-" | trunc 63 | trimSuffix "-" }}
   labels:
     chart: {{ template "chart-neuvector.chart" $ }}
     release: {{ $.Release.Name }}

--- a/neuvector-azure-keyvault/values.yaml
+++ b/neuvector-azure-keyvault/values.yaml
@@ -38,6 +38,9 @@ groups: []
 config:
   sleep: 180
   forceLicenseUpdate: false
+  # Set to true via a Flux patch to enable verbose curl output and response body
+  # logging for troubleshooting without requiring a code change.
+  debug: false
 
 neuvector:
   registry: hmctsprod.azurecr.io

--- a/neuvector-azure-keyvault/values.yaml
+++ b/neuvector-azure-keyvault/values.yaml
@@ -15,8 +15,9 @@ rules:
   response:
     # Response rules are rendered as NvResponseRuleSecurityRule CRDs (NeuVector 2.8.8+).
     # Each entry maps 1:1 to a CRD instance. The 'name' field is used as the
-    # Kubernetes resource name and must be a valid DNS subdomain (lowercase,
-    # alphanumeric, hyphens only).
+    # Kubernetes resource name and must be a valid DNS subdomain (lowercase
+    # alphanumeric characters, '-' or '.', and must start and end with an
+    # alphanumeric character).
     # Available events: event, security-event, cve-report, compliance, admission-control
     # Available actions: quarantine, suppress-log, webhook
     # Example:

--- a/neuvector-azure-keyvault/values.yaml
+++ b/neuvector-azure-keyvault/values.yaml
@@ -13,6 +13,22 @@ rules:
     admClientMode: "service"
     service: "neuvector"
   response:
+    # Response rules are rendered as NvResponseRuleSecurityRule CRDs (NeuVector 2.8.8+).
+    # Each entry maps 1:1 to a CRD instance. The 'name' field is used as the
+    # Kubernetes resource name and must be a valid DNS subdomain (lowercase,
+    # alphanumeric, hyphens only).
+    # Available events: event, security-event, cve-report, compliance, admission-control
+    # Available actions: quarantine, suppress-log, webhook
+    # Example:
+    #   policies:
+    #     - name: admission-control-denied
+    #       event: admission-control
+    #       conditions:
+    #         - type: name
+    #           value: Admission.Control.Denied
+    #       actions:
+    #         - webhook
+    #       disable: false
     policies: []
   network: []
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-30727

### Change description
NeuVector post-install hook rewrite for 2.8.12
Purpose
Neuvector 2.8.8 introduced a forced password reset on new admin log in which was causing upgrades to fail. The following changes to the configmap file/script accommodate this by providing different log in options 
- Bootstrap - provided by Neuvector chart
- Existing Admin password - pulled from Key Vault
- Existing new Admin password - pulled from Key Vault

Response rule changes are based on the migration of response rules to a CRD. The chart will now supply the values as CRD spec and the new response-rules.yaml template will handle creation (this replaces the API method used in the configmap script previously, the rules are unchanged).

Logging output is now more secure, verbose output is now disabled by default but can be enabled via values if required. Ensures passwords, licenses and certificates are not exposed.

#### Details
Authentication
Replaced fragile inline curl --fail calls with typed helper functions (curl_json, curl_download, curl_file) that capture HTTP status and response body separately. Added a structured three-source fallback: bootstrap → keyvault-admin → keyvault-new-admin. Handles NeuVector's forced first-login reset flow automatically on fresh installs.

License reconciliation
NeuVector 2.8.12 removed the direct license update endpoint. License is now managed via config export/import: export current config, swap the license key using awk, re-import as gzip. Fixed the export URL (?raw → ?raw=true). Import polling handles the controller restart mid-import (was causing a spurious 401 failure on first install).

Response rules
Removed from the hook script entirely — now managed declaratively as NvResponseRuleSecurityRule CRDs by Helm.

Debug mode
New config.debug: false value. Set to true via a Flux patch to enable verbose curl output and response body logging for troubleshooting without touching the chart code.

Security
Removed -v from all curl calls — was leaking X-Auth-Token request headers and full JWT auth responses into pod logs, accessible to anyone with kubectl logs access to the neuvector namespace
Removed unconditional response body logging — was printing full JWT tokens and config content to stdout on every API call
Passwords never appear in process listings — auth payloads built via jq reading from stdin rather than inline string interpolation
Verbose logging is opt-in only — gated behind config.debug: true; README includes an explicit warning to remove the flag after use